### PR TITLE
369 add vehicles owners exercises to zoo

### DIFF
--- a/302-complex-join.yaml
+++ b/302-complex-join.yaml
@@ -52,7 +52,9 @@ questions:
     title: List all data
     body: |
       Join the two tables so that every column and record appears, regardless of 
-      if there is not an owner_id. Your output should look like this:
+      if there is not an owner_id. 
+      
+      Your output should look like this:
 
       ```
       id | first_name | id |  make  |  model  | year |  price   | owner_id
@@ -93,7 +95,9 @@ questions:
     body: |
       Count the number of cars for each owner who has a vehicle. Display the 
       owners first_name and count of vehicles. The first_name should be ordered 
-      in ascending order. Your output should look like this:
+      in ascending order. 
+      
+      Your output should look like this:
 
       ```
       first_name | count
@@ -185,4 +189,3 @@ questions:
           LEFT OUTER JOIN vehicles v ON o.id = v.owner_id
         GROUP BY o.id
         ORDER BY count;
-  

--- a/302-complex-join.yaml
+++ b/302-complex-join.yaml
@@ -1,0 +1,188 @@
+id: complex-joins
+title: Even more joining
+description: |
+  Learn more ways to use joined tables.
+welcome: |
+  This tutorial continues to cover `JOIN`. The database consists of two tables,
+  vehicles and owners.
+
+schema: |
+  ##### The `vehicles` table
+
+  | Column       | Type         | Nullable | Notes                   |
+  | -----------  | ------------ | -------- | ----------------------- |
+  | id           | int          | not null |                         |
+  | make         | text         | not null |                         |
+  | model        | text         | not null |                         |
+  | year         | int          | not null |                         |
+  | price        | num          | not null |                         |
+  | owner_id     | int          | not null |                         |
+
+  - Indexes:
+    - "id" PRIMARY KEY
+    - "owner_id" FOREIGN KEY, owners
+
+  ###### Sample data
+
+  | id |  make  |  model  | year |  price   | owner_id  |
+  |----|--------|---------|------|----------|---------- |
+  | 1  | Toyota | Corolla | 2002 |  2999.99 |        1  |
+  | 2  | Honda  | Civic   | 2012 | 12999.99 |        1  |
+
+
+  ##### The `owners` table
+
+  | Column      | Type         | Nullable | Notes                   |
+  | ----------- | ------------ | -------- | ----------------------- |
+  | id          | int          | not null |                         |
+  | first_name  | text         | not null |                         |
+
+  - Indexes:
+    - "id" PRIMARY KEY
+
+  ###### Sample data
+
+  | id  | first_name |
+  | ----|----------- |
+  |  1  | Bob        |
+  |  2  | Jane       |
+
+questions:
+  fully-combine-tables:
+    title: List all data
+    body: |
+      Join the two tables so that every column and record appears, regardless of 
+      if there is not an owner_id. Your output should look like this:
+
+      ```
+      id | first_name | id |  make  |  model  | year |  price   | owner_id
+      ---|------------|----|--------|---------|------|----------|----------
+       1 | Bob        |  1 | Toyota | Corolla | 2002 |  2999.99 |        1
+       1 | Bob        |  2 | Honda  | Civic   | 2012 | 12999.99 |        1
+       2 | Jane       |  3 | Nissan | Altima  | 2016 | 23999.99 |        2
+       2 | Jane       |  4 | Subaru | Legacy  | 2006 |  5999.99 |        2
+       3 | Melody     |  5 | Ford   | F150    | 2012 |  2599.99 |        3
+       3 | Melody     |  6 | GMC    | Yukon   | 2016 | 12999.99 |        3
+       4 | Sarah      |  7 | GMC    | Yukon   | 2014 | 22999.99 |        4
+       4 | Sarah      |  8 | Toyota | Avalon  | 2009 | 12999.99 |        4
+       4 | Sarah      |  9 | Toyota | Camry   | 2013 | 12999.99 |        4
+       5 | Alex       | 10 | Honda  | Civic   | 2001 |  7999.99 |        5
+       6 | Shana      | 11 | Nissan | Altima  | 1999 |  1899.99 |        6
+       6 | Shana      | 12 | Lexus  | ES350   | 1998 |  1599.99 |        6
+       6 | Shana      | 13 | BMW    | 300     | 2012 | 22999.99 |        6
+       6 | Shana      | 14 | BMW    | 700     | 2015 | 52999.99 |        6
+       7 | Maya       |    |        |         |      |          |
+       8 | Jane       |    |        |         |      |          |
+      ```
+      Warning:
+
+      The same name isn't always the same person!
+
+      There are two Janes in the database, and they are different people; they just 
+      share that first name. Check that you get both Janes in the output!
+
+    initial: |
+
+    solution: |
+      SELECT *
+        FROM owners o
+          FULL OUTER JOIN vehicles v ON o.id = v.owner_id;
+  
+  count-cars:
+    title: Count the number of cars per car owner
+    body: |
+      Count the number of cars for each owner who has a vehicle. Display the 
+      owners first_name and count of vehicles. The first_name should be ordered 
+      in ascending order. Your output should look like this:
+
+      ```
+      first_name | count
+      -----------|-------
+      Alex       |     1
+      Bob        |     2
+      Jane       |     2
+      Melody     |     2
+      Sarah      |     3
+      Shana      |     4
+      ```
+
+    initial: |
+
+    solution: |
+      SELECT 
+        first_name,
+        COUNT(*)
+        FROM owners o
+          JOIN vehicles v ON o.id = v.owner_id
+        GROUP BY o.id
+        ORDER BY first_name;
+  
+  count-cars-and-find-avg-price-per-owner:
+    title: Calculate count of cars and average price per owner
+    body: |
+      Count the number of cars for each owner who has a vehicle and display 
+      the average price for each of the cars as integers. Display the owner's 
+      first_name, average price, and count of vehicles. The first_name should 
+      be ordered in descending order. Only display results with more than one 
+      vehicle and an average price greater than 10000. 
+      
+      Your output should look like this:
+
+      ```
+      first_name | average_price | count
+      -----------|---------------|-------
+      Shana      |         19875 |     4
+      Sarah      |         16333 |     3
+      Jane       |         15000 |     2
+      ```
+
+    initial: |
+
+    solution: |
+      SELECT 
+        first_name,
+        ROUND(AVG(price)) AS average_price,
+        COUNT(*)
+        FROM owners o
+          JOIN vehicles v ON o.id = v.owner_id
+        GROUP BY first_name
+        HAVING COUNT(owner_id) > 1
+          AND ROUND(AVG(price)) > 10000
+        ORDER BY count DESC;
+  
+  all-owners-with-car-counts:
+    title: Display all owners and the count of their cars
+    body: |
+      Similar to above, write a query that shows the first_name and count for 
+      all people in the owners table, whether they own a vehicle or not. Make 
+      sure the count is accurate for people who don't own vehicles. Order the 
+      results by count (and use first_name) to break ordering ties.
+      
+      Your output should look like this:
+
+      ```
+      first_name | count
+      -----------|-------
+      Maya       |     0
+      Alex       |     1
+      Bob        |     2
+      Jane       |     2
+      Melody     |     2
+      Sarah      |     3
+      Shana      |     4
+      Jane       |     0
+      ```
+
+      This may require some research.
+
+    initial: |
+
+    solution: |
+      SELECT 
+        first_name,
+        COUNT(owner_id)
+        FROM owners o
+          LEFT OUTER JOIN vehicles v ON o.id = v.owner_id
+        GROUP BY o.id
+        ORDER BY count;
+  

--- a/vehicles.sql
+++ b/vehicles.sql
@@ -1,0 +1,39 @@
+CREATE TABLE owners (
+  id SERIAL PRIMARY KEY,
+  first_name TEXT NOT NULL);
+
+CREATE TABLE vehicles (
+  id SERIAL PRIMARY KEY,
+  make TEXT NOT NULL,
+  model TEXT NOT NULL,
+  year INT NOT NULL,
+  price NUMERIC(10, 2) NOT NULL,
+  owner_id INTEGER NOT NULL REFERENCES owners);
+
+INSERT INTO owners (first_name)
+  VALUES
+    ('Bob'),
+    ('Jane'),
+    ('Melody'),
+    ('Sarah'),
+    ('Alex'),
+    ('Shana'),
+    ('Maya'),
+    ('Jane');
+
+INSERT INTO vehicles (make, model, year, price, owner_id)
+  VALUES
+    ('Toyota', 'Corolla', 2002, 2999.99, 1),
+    ('Honda', 'Civic', 2012, 12999.99, 1),
+    ('Nissan', 'Altima', 2016, 23999.99, 2),
+    ('Subaru', 'Legacy', 2006, 5999.99, 2),
+    ('Ford', 'F150', 2012, 2599.99, 3),
+    ('GMC', 'Yukon', 2016, 12999.99, 3),
+    ('GMC', 'Yukon', 2014, 22999.99, 4),
+    ('Toyota', 'Avalon', 2009, 12999.99, 4),
+    ('Toyota', 'Camry', 2013, 12999.99, 4),
+    ('Honda', 'Civic', 2001, 7999.99, 5),
+    ('Nissan', 'Altima', 1999, 1899.99, 6),
+    ('Lexus', 'ES350', 1998, 1599.99, 6),
+    ('BMW', '300', 2012, 22999.99, 6),
+    ('BMW', '700', 2015, 52999.99, 6);


### PR DESCRIPTION
Tied to issue 369 in curric repo-- added seed file of vehicle/owner data and associated YAML file with questions from the sql-joins exercise (including the 1 further study question). Curious for some thoughts on if this new module should come before or after the 301-more-join module.

Additionally, I noticed that the solution that we have for the further study question (currently in 302-complex-join.yaml as `all-owners-with-car-counts`) isn't actually correct with respect to the ordering requested. I've tried a lot of different combinations of ordering by count & first_name and can't quite get the result to match the example output. I'm curious what the trick is here or if there's a particular new operation I should look into (I've seen things about rank, ties, etc).

All thoughts/feedback welcome!